### PR TITLE
Update to the latest loader, which removes MinecraftJarTransformer

### DIFF
--- a/properties.json
+++ b/properties.json
@@ -1,5 +1,5 @@
 {
-    "berry_version": "0.5.2+2025062601",
+    "berry_version": "0.5.2+2025062801",
     "berry_repo": "https://azfs.pages.dev/berry-dist/{version}/{jarname}.jar",
     "minecraft_version": "1.21.5",
     "fabric_loader_version": "0.16.14",


### PR DESCRIPTION
The latest version of Berry Loader removes MinecraftJarTransformer, which used to be a temporary solution but is now unnecessary.