### PR TITLE
Bump loader version to fix a hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Currently, Petunia supports loading [Fabric](https://fabricmc.net) mods.
 Tested mods (in Minecraft 1.21.5) are listed below:
 | Mod                | Version        |
 |--------------------|----------------|
-| Fabric Loader      | 0.16.14*       |
+| Fabric Loader      | 0.16.14        |
 | Fabric API         | 0.119.6+1.21.5 |
 | Apple Skin         | 3.0.6          |
 | CICADA             | 0.13.0         |
@@ -19,9 +19,6 @@ Tested mods (in Minecraft 1.21.5) are listed below:
 | Sodium             | 0.6.12         |
 | Tech Reborn        | 5.13.0         |
 | Ultimate Furnace   | 1.3.2          |
-
-*: A special version of Fabric Loader (with `META-INF/services/` removed) is required for
-Petunia to work consistently. The link can be found in `project.json`.
 
 (These are just random mods I've chosen for testing, sorted alphabetically except Fabric)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Petunia is the mod that aims inter-loader compatibility.
 
-Currenty, Petunia supports loading [Fabric](https://fabricmc.net) mods.
+Currently, Petunia supports loading [Fabric](https://fabricmc.net) mods.
 
 Tested mods (in Minecraft 1.21.5) are listed below:
 | Mod                | Version        |
@@ -31,11 +31,11 @@ If you have tested it and found it compatible, you can also open an issue to hav
 ## Development
 Please refer to [Berry Loader](https://github.com/VoidSingularity/berry) for more information.
 
-To setup the build environment, run `init.py`, this will automatically download the necessary buildscript templates.
+To set up the build environment, run `init.py`, this will automatically download the necessary buildscript templates.
 
 To build a jar, run task `main`. The output jar will be in `output/`.
 
-To add Fabric mods for testing, you can simply put the mods into `.cache/extramods/`. The buildscript will automatically add them to the runtime mods directory.
+To add Fabric mods for testing, you can simply put the mods into `.cache/extramods/`. The buildscript will automatically add them to the runtime mods' directory.
 
 ## License
 **SPECIAL NOTICE: To work with this project, you agree with Mojang's [End User License Agreement](https://www.minecraft.net/en-us/eula). If you do not agree, you may not download

--- a/init.py
+++ b/init.py
@@ -14,7 +14,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Change the source if you need
-source = 'https://azfs.pages.dev/berry-dist/0.5.2+2025062705/'
+source = 'https://azfs.pages.dev/berry-dist/0.5.2+2025062901/'
 
 li = [
     'build.py',

--- a/project.json
+++ b/project.json
@@ -1,4 +1,5 @@
 {
+    "repos": [ "https://maven.fabricmc.net/" ],
     "output_mod": "main",
     "packages": {
         "main": {
@@ -20,14 +21,14 @@
             "class": "berry.unify.ExternalLibrariesGenerated"
         },
         "urls": [
-            "https://azfs.pages.dev/fabric-loader/${fabric_loader_version}.jar",
-            "https://maven.fabricmc.net/net/fabricmc/tiny-remapper/${tiny_remapper_version}/tiny-remapper-${tiny_remapper_version}.jar",
-            "https://maven.fabricmc.net/net/fabricmc/mapping-io/${mapping_io_version}/mapping-io-${mapping_io_version}.jar",
-            "https://maven.fabricmc.net/net/fabricmc/access-widener/${access_widener_version}/access-widener-${access_widener_version}.jar",
-            "https://maven.fabricmc.net/net/fabricmc/intermediary/${minecraft_version}/intermediary-${minecraft_version}.jar",
-            "https://repo1.maven.org/maven2/org/jetbrains/annotations/${jetbrains_annotations_version}/annotations-${jetbrains_annotations_version}.jar",
-            "https://repo1.maven.org/maven2/org/sat4j/org.sat4j.pb/${sat4j_version}/org.sat4j.pb-${sat4j_version}.jar",
-            "https://repo1.maven.org/maven2/org/sat4j/org.sat4j.core/${sat4j_version}/org.sat4j.core-${sat4j_version}.jar"
+            "net.fabricmc:fabric-loader:${fabric_loader_version}",
+            "net.fabricmc:tiny-remapper:${tiny_remapper_version}",
+            "net.fabricmc:mapping-io:${mapping_io_version}",
+            "net.fabricmc:access-widener:${access_widener_version}",
+            "net.fabricmc:intermediary:${minecraft_version}",
+            "org.jetbrains:annotations:${jetbrains_annotations_version}",
+            "org.sat4j:org.sat4j.pb:${sat4j_version}",
+            "org.sat4j:org.sat4j.core:${sat4j_version}"
         ]
     },
     "runs": {

--- a/properties.json
+++ b/properties.json
@@ -1,5 +1,5 @@
 {
-    "berry_version": "0.5.2+2025062801",
+    "berry_version": "0.5.2+2025062901",
     "berry_repo": "https://azfs.pages.dev/berry-dist/{version}/{jarname}.jar",
     "minecraft_version": "1.21.5",
     "fabric_loader_version": "0.16.14",

--- a/properties.json
+++ b/properties.json
@@ -1,5 +1,5 @@
 {
-    "berry_version": "0.5.2+2025062601",
+    "berry_version": "0.5.2+2025062801",
     "berry_repo": "https://azfs.pages.dev/berry-dist/{version}/{jarname}.jar",
     "minecraft_version": "1.21.5",
     "fabric_loader_version": "0.16.14",


### PR DESCRIPTION
Previously, a special version of Fabric Loader is required for Petunia to work properly. After Berry Loader's update, this is no longer needed.